### PR TITLE
Additional gunshot options

### DIFF
--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
@@ -173,9 +173,22 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
             bodypart:setDeepWounded(deepWound)
             bodypart:setBleedingTime(bleedTime)
         else
-            bodypart:setHaveBullet(true, 0)
+			-- Decides whether to add a bullet based on chance in sandbox settings
+			if ZombRand(100) > Advanced_trajectory.throughChance then
+				bodypart:setHaveBullet(true, 0)
+			else
+				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
+				bodyPart:generateDeepWound();
+			end
         end
-
+		
+		-- Decides whether to inflict a fracture based on chance in sandbox settings
+		if ZombRand(100) <= Advanced_trajectory.fractureChance then
+			if bodyPart:getFractureTime() < 21 then
+				bodyPart:setFractureTime(21)
+			end
+		end
+		
         -- Destroy bandage if bandaged
         if bodypart:bandaged() then
             bodypart:setBandaged(false, 0)

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
@@ -174,7 +174,7 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
             bodypart:setBleedingTime(bleedTime)
         else
 			-- Decides whether to add a bullet based on chance in sandbox settings
-			if ZombRand(100) > Advanced_trajectory.throughChance then
+			if ZombRand(0, 100)+1 > Advanced_trajectory.throughChance then
 				bodypart:setHaveBullet(true, 0)
 			else
 				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
@@ -183,7 +183,7 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
         end
 		
 		-- Decides whether to inflict a fracture based on chance in sandbox settings
-		if ZombRand(100) <= Advanced_trajectory.fractureChance then
+		if ZombRand(0, 100)+1 <= Advanced_trajectory.fractureChance then
 			if bodyPart:getFractureTime() < 21 then
 				bodyPart:setFractureTime(21)
 			end

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
@@ -1647,7 +1647,7 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
             bodypart:setBleedingTime(bleedTime)
         else
 			-- Decides whether to add a bullet based on chance in sandbox settings
-			if ZombRand(100) > Advanced_trajectory.throughChance then
+			if ZombRand(0, 100)+1 > Advanced_trajectory.throughChance then
 				bodypart:setHaveBullet(true, 0)
 			else
 				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
@@ -1656,7 +1656,7 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
         end
 		
 		-- Decides whether to inflict a fracture based on chance in sandbox settings
-		if ZombRand(100) <= Advanced_trajectory.fractureChance then
+		if ZombRand(0, 100)+1 <= Advanced_trajectory.fractureChance then
 			if bodyPart:getFractureTime() < 21 then
 				bodyPart:setFractureTime(21)
 			end

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
@@ -1646,8 +1646,22 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
             bodypart:setDeepWounded(deepWound)
             bodypart:setBleedingTime(bleedTime)
         else
-            bodypart:setHaveBullet(true, 0)
+			-- Decides whether to add a bullet based on chance in sandbox settings
+			if ZombRand(100) > Advanced_trajectory.throughChance then
+				bodypart:setHaveBullet(true, 0)
+			else
+				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
+				bodyPart:generateDeepWound();
+			end
         end
+		
+		-- Decides whether to inflict a fracture based on chance in sandbox settings
+		if ZombRand(100) <= Advanced_trajectory.fractureChance then
+			if bodyPart:getFractureTime() < 21 then
+				bodyPart:setFractureTime(21)
+			end
+		end
+		
         -- Destroy bandage if bandaged
         if bodypart:bandaged() then
             bodypart:setBandaged(false, 0)

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -53,6 +53,12 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectorybodyShotDmgPlayerMultiplier_tooltip = "Multiplier on base damage for bodyshot",
 	Sandbox_Advanced_trajectoryfootShotDmgPlayerMultiplier = "Footshot Damage Multiplier (PVP)",
 	Sandbox_Advanced_trajectoryfootShotDmgPlayerMultiplier_tooltip = "Multiplier on base damage for footshot",
+	
+	Sandbox_Advanced_trajectoryfractureChance = "Gunshot Fracture Chance (PVP)",
+	Sandbox_Advanced_trajectoryfractureChance_tooltip = "Chance that a gunshot wound will cause a fracture",
+	
+	Sandbox_Advanced_trajectorythroughChance = "Gunshot Clean Through Chance (PVP)",
+	Sandbox_Advanced_trajectorythroughChance_tooltip = "Chance that a gunshot wound will not inflict a lodged bullet",
 
 	Sandbox_Advanced_trajectoryenableBulletPenFlesh = "Enable Bullet Penetration Through Flesh",
 	Sandbox_Advanced_trajectorypenDamageReductionMultiplier = "Bullet Penetration Reduction Multiplier",

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
@@ -627,6 +627,25 @@ option Advanced_trajectory.footShotDmgPlayerMultiplier
 	page = Advanced_trajectory_damage,
 	translation = Advanced_trajectoryfootShotDmgPlayerMultiplier,
 }
+option Advanced_trajectory.fractureChance
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 25,
+	page = Advanced_trajectory_damage,
+	translation = Advanced_trajectoryfractureChance,
+}
+
+option Advanced_trajectory.throughChance
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 25,
+	page = Advanced_trajectory_damage,
+	translation = Advanced_trajectorythroughChance,
+}
 option Advanced_trajectory.critChanceModifier
 {
 	type = double,


### PR DESCRIPTION
Adds a chance for gunshot wounds in PVP to inflict fractures, and adds a chance for gunshot wounds to not inflict a lodged bullet; both are configurable in the sandbox options in the damage page.

Offered on the Workshop page to write up these changes, took me a bit to get around to it but I made sure to keep it lightweight and out-of-the-way.