### PR TITLE
December Update

### DIFF
--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_aimtex.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_aimtex.lua
@@ -55,6 +55,10 @@ function Advanced_trajectory.panel:prerender()
         AR,AG,AB = getSandboxOptions():getOptionByName("Advanced_trajectory.crosshairRed"):getValue(), getSandboxOptions():getOptionByName("Advanced_trajectory.crosshairGreen"):getValue() , getSandboxOptions():getOptionByName("Advanced_trajectory.crosshairBlue"):getValue() 
     end
 
+    if Advanced_trajectory.isOverDistanceLimit then
+        AR,AG,AB = getSandboxOptions():getOptionByName("Advanced_trajectory.crosshairRedLimit"):getValue(), getSandboxOptions():getOptionByName("Advanced_trajectory.crosshairGreenLimit"):getValue() , getSandboxOptions():getOptionByName("Advanced_trajectory.crosshairBlueLimit"):getValue() 
+    end
+
     local transparency  = Advanced_trajectory.alpha
 
     local shakyEffect   = Advanced_trajectory.stressEffect + Advanced_trajectory.painEffect

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_aimtex.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_aimtex.lua
@@ -61,7 +61,10 @@ function Advanced_trajectory.panel:prerender()
 
     local transparency  = Advanced_trajectory.alpha
 
-    local shakyEffect   = Advanced_trajectory.stressEffect + Advanced_trajectory.painEffect
+    local shakyEffect   = Advanced_trajectory.stressEffect + Advanced_trajectory.painEffect + Advanced_trajectory.panicEffect
+    if shakyEffect > 10 then
+        shakyEffect = 10
+    end
 
     self:drawTextureScaled(self.texturetable[1], (self.width/2 -texturescal/2)              - ZombRand(shakyEffect), (self.height/2 - multiper- texturescal/2)  - ZombRand(shakyEffect),  texturescal, texturescal, transparency, AR, AG, AB)
     self:drawTextureScaled(self.texturetable[2], (self.width/2 +multiper -texturescal/2)    + ZombRand(shakyEffect), (self.height/2 -texturescal/2)             + ZombRand(shakyEffect),  texturescal, texturescal, transparency, AR, AG, AB)

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
@@ -173,8 +173,21 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
             bodypart:setDeepWounded(deepWound)
             bodypart:setBleedingTime(bleedTime)
         else
-            bodypart:setHaveBullet(true, 0)
+            -- Decides whether to add a bullet based on chance in sandbox settings
+			if ZombRand(100) > Advanced_trajectory.throughChance then
+				bodypart:setHaveBullet(true, 0)
+			else
+				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
+				bodyPart:generateDeepWound();
+			end
         end
+        
+        -- Decides whether to inflict a fracture based on chance in sandbox settings
+		if ZombRand(100) <= Advanced_trajectory.fractureChance then
+			if bodyPart:getFractureTime() < 21 then
+				bodyPart:setFractureTime(21)
+			end
+		end
 
         -- Destroy bandage if bandaged
         if bodypart:bandaged() then

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
@@ -174,7 +174,7 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
             bodypart:setBleedingTime(bleedTime)
         else
             -- Decides whether to add a bullet based on chance in sandbox settings
-			if ZombRand(100) > Advanced_trajectory.throughChance then
+			if ZombRand(0, 100)+1 > Advanced_trajectory.throughChance then
 				bodypart:setHaveBullet(true, 0)
 			else
 				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
@@ -183,7 +183,7 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
         end
         
         -- Decides whether to inflict a fracture based on chance in sandbox settings
-		if ZombRand(100) <= Advanced_trajectory.fractureChance then
+		if ZombRand(0, 100)+1 <= Advanced_trajectory.fractureChance then
 			if bodyPart:getFractureTime() < 21 then
 				bodyPart:setFractureTime(21)
 			end

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
@@ -174,7 +174,7 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
             bodypart:setBleedingTime(bleedTime)
         else
             -- Decides whether to add a bullet based on chance in sandbox settings
-			if ZombRand(0, 100)+1 > Advanced_trajectory.throughChance then
+			if ZombRand(100) >= getSandboxOptions():getOptionByName("Advanced_trajectory.throughChance"):getValue() then
 				bodypart:setHaveBullet(true, 0)
 			else
 				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
@@ -183,7 +183,7 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
         end
         
         -- Decides whether to inflict a fracture based on chance in sandbox settings
-		if ZombRand(0, 100)+1 <= Advanced_trajectory.fractureChance then
+		if ZombRand(100) <= getSandboxOptions():getOptionByName("Advanced_trajectory.fractureChance"):getValue() then
 			if bodyPart:getFractureTime() < 21 then
 				bodyPart:setFractureTime(21)
 			end

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_clientdeal.lua
@@ -164,29 +164,22 @@ local function damagePlayershotPVP(player, playerShot, damage, baseGunDmg, headS
 
     if defense < 0.5 then
         --print("WOUNDED")
+
         if bodypart:haveBullet() then
-            local deepWound = bodypart:isDeepWounded()
-            local deepWoundTime = bodypart:getDeepWoundTime()
             local bleedTime = bodypart:getBleedingTime()
-            --bodypart:setHaveBullet(false, 0)
-            bodypart:setDeepWoundTime(deepWoundTime)
-            bodypart:setDeepWounded(deepWound)
             bodypart:setBleedingTime(bleedTime)
         else
             -- Decides whether to add a bullet based on chance in sandbox settings
-			if ZombRand(100) >= getSandboxOptions():getOptionByName("Advanced_trajectory.throughChance"):getValue() then
-				bodypart:setHaveBullet(true, 0)
-			else
-				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
-				bodyPart:generateDeepWound();
-			end
+            if ZombRand(100) >= getSandboxOptions():getOptionByName("Advanced_trajectory.throughChance"):getValue() then
+                bodypart:setHaveBullet(true, 0)
+            else
+                bodypart:generateDeepWound()
+            end
         end
         
         -- Decides whether to inflict a fracture based on chance in sandbox settings
 		if ZombRand(100) <= getSandboxOptions():getOptionByName("Advanced_trajectory.fractureChance"):getValue() then
-			if bodyPart:getFractureTime() < 21 then
-				bodyPart:setFractureTime(21)
-			end
+            bodypart:setFractureTime(21)
 		end
 
         -- Destroy bandage if bandaged

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
@@ -1683,7 +1683,7 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
             bodypart:setBleedingTime(bleedTime)
         else
             -- Decides whether to add a bullet based on chance in sandbox settings
-			if ZombRand(100) > Advanced_trajectory.throughChance then
+			if ZombRand(0, 100)+1 > Advanced_trajectory.throughChance then
 				bodypart:setHaveBullet(true, 0)
 			else
 				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
@@ -1692,7 +1692,7 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
         end
         
         -- Decides whether to inflict a fracture based on chance in sandbox settings
-		if ZombRand(100) <= Advanced_trajectory.fractureChance then
+		if ZombRand(0, 100)+1 <= Advanced_trajectory.fractureChance then
 			if bodyPart:getFractureTime() < 21 then
 				bodyPart:setFractureTime(21)
 			end

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
@@ -462,27 +462,17 @@ function Advanced_trajectory.checkiswallordoor(square,bulletAngle,bulletPosition
     -- end
     
     if squarecar and ((squarecar:getX() -playerPosition[1] )^2  + (squarecar:getY() -playerPosition[2])^2)  >8 then
-
-
         if nosfx then return true end
 
-
         if ((squarecar:getX() -bulletPosition[1] )^2  + (squarecar:getY() -bulletPosition[2])^2) < 2.8  then
-
             if getSandboxOptions():getOptionByName("AT_VehicleDamageenable"):getValue() then
-
-                
                 squarecar:HitByVehicle(squarecar, 0.3)
-                
             end
+
             return true
-            
         end 
-        
-        
     end
 
-    
 end
 
 -----------------------------------

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
@@ -1682,8 +1682,22 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
             bodypart:setDeepWounded(deepWound)
             bodypart:setBleedingTime(bleedTime)
         else
-            bodypart:setHaveBullet(true, 0)
+            -- Decides whether to add a bullet based on chance in sandbox settings
+			if ZombRand(100) > Advanced_trajectory.throughChance then
+				bodypart:setHaveBullet(true, 0)
+			else
+				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
+				bodyPart:generateDeepWound();
+			end
         end
+        
+        -- Decides whether to inflict a fracture based on chance in sandbox settings
+		if ZombRand(100) <= Advanced_trajectory.fractureChance then
+			if bodyPart:getFractureTime() < 21 then
+				bodyPart:setFractureTime(21)
+			end
+		end
+
         -- Destroy bandage if bandaged
         if bodypart:bandaged() then
             bodypart:setBandaged(false, 0)

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
@@ -1683,7 +1683,7 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
             bodypart:setBleedingTime(bleedTime)
         else
             -- Decides whether to add a bullet based on chance in sandbox settings
-			if ZombRand(0, 100)+1 > Advanced_trajectory.throughChance then
+			if ZombRand(100) >= getSandboxOptions():getOptionByName("Advanced_trajectory.throughChance"):getValue() then
 				bodypart:setHaveBullet(true, 0)
 			else
 				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
@@ -1692,7 +1692,7 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
         end
         
         -- Decides whether to inflict a fracture based on chance in sandbox settings
-		if ZombRand(0, 100)+1 <= Advanced_trajectory.fractureChance then
+		if ZombRand(100) <= getSandboxOptions():getOptionByName("Advanced_trajectory.fractureChance"):getValue() then
 			if bodyPart:getFractureTime() < 21 then
 				bodyPart:setFractureTime(21)
 			end

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/client/Advanced_trajectory_core.lua
@@ -779,7 +779,7 @@ function Advanced_trajectory.OnPlayerUpdate()
         
         local targetDist = Advanced_trajectory.targetDistance
 
-        print("target / maxDistance / limit: ", targetDist, " || ", maxDistance, " || ", distanceLimit)
+        --print("target / maxDistance / limit: ", targetDist, " || ", maxDistance, " || ", distanceLimit)
 
         if targetDist > maxDistance then
             targetDist = maxDistance
@@ -1673,29 +1673,22 @@ function damagePlayershot(player, damage, baseGunDmg, headShotDmg, bodyShotDmg, 
 
     if defense < 0.5 then
         --print("WOUNDED")
+
         if bodypart:haveBullet() then
-            local deepWound = bodypart:isDeepWounded()
-            local deepWoundTime = bodypart:getDeepWoundTime()
             local bleedTime = bodypart:getBleedingTime()
-            --bodypart:setHaveBullet(false, 0)
-            bodypart:setDeepWoundTime(deepWoundTime)
-            bodypart:setDeepWounded(deepWound)
             bodypart:setBleedingTime(bleedTime)
         else
             -- Decides whether to add a bullet based on chance in sandbox settings
-			if ZombRand(100) >= getSandboxOptions():getOptionByName("Advanced_trajectory.throughChance"):getValue() then
-				bodypart:setHaveBullet(true, 0)
-			else
-				-- Making sure that the deep wound is still inflicted, even if we don't inflict a lodged bullet
-				bodyPart:generateDeepWound();
-			end
+            if ZombRand(100) >= getSandboxOptions():getOptionByName("Advanced_trajectory.throughChance"):getValue() then
+                bodypart:setHaveBullet(true, 0)
+            else
+                bodypart:generateDeepWound()
+            end
         end
         
         -- Decides whether to inflict a fracture based on chance in sandbox settings
 		if ZombRand(100) <= getSandboxOptions():getOptionByName("Advanced_trajectory.fractureChance"):getValue() then
-			if bodyPart:getFractureTime() < 21 then
-				bodyPart:setFractureTime(21)
-			end
+            bodypart:setFractureTime(21)
 		end
 
         -- Destroy bandage if bandaged

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -1,9 +1,12 @@
 Sandbox_EN = {
 
     Sandbox_Advanced_trajectory = "Advanced Trajectory (MAIN)",
+	Sandbox_Advanced_trajectory_movement = "Advanced Trajectory (MOVEMENT)",
 	Sandbox_Advanced_trajectory_damage = "Advanced Trajectory (DAMAGE)",
+	Sandbox_Advanced_trajectory_recoil = "Advanced Trajectory (RECOIL)",
 	Sandbox_Advanced_trajectory_shotgun = "Advanced Trajectory (SHOTGUN)",
 	Sandbox_Advanced_trajectory_moodles = "Advanced Trajectory (MOODLES)",
+	Sandbox_Advanced_trajectory_hitOrMiss = "Advanced Trajectory (HIT OR MISS)",
 	Sandbox_Advanced_trajectory_crosshair = "Advanced Trajectory (CROSSHAIR)",
 	Sandbox_Advanced_trajectory_debug = "Advanced Trajectory (DEBUG / DONT TOUCH)",
 	Sandbox_Advanced_trajectory_XP = "Advanced Trajectory (EXP)",
@@ -63,18 +66,8 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectorycritChanceModifierShotgunsOnly = "Critchance Modifier (Shotguns)",
 	Sandbox_Advanced_trajectorycritChanceModifierShotgunsOnly_tooltip = "Shotguns crit chance is only affected by their stat and aiming level (not bloom). Default value is 10 meaning the game decides a random value from 1 to (100 - 10) and if value is <= crit stat, then crit.",
 
-	Sandbox_Advanced_trajectorycrosshairRedMain = "Crosshair Main Red Value",
-	Sandbox_Advanced_trajectorycrosshairRedMain_tooltip = "Linked to crosshair color. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
-	Sandbox_Advanced_trajectorycrosshairBlueMain = "Crosshair Main Blue Value",
-	Sandbox_Advanced_trajectorycrosshairBlueMain_tooltip = "Linked to crosshair color. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
-	Sandbox_Advanced_trajectorycrosshairGreenMain = "Crosshair Main Green Value",
-	Sandbox_Advanced_trajectorycrosshairGreenMain_tooltip = "Linked to crosshair color. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
-	Sandbox_Advanced_trajectorycrosshairRed = "Crosshair Focus Red Value",
-	Sandbox_Advanced_trajectorycrosshairRed_tooltip = "Linked to color when there is zero bloom on crosshair. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
-	Sandbox_Advanced_trajectorycrosshairBlue = "Crosshair Focus Blue Value",
-	Sandbox_Advanced_trajectorycrosshairBlue_tooltip = "Linked to color when there is zero bloom on crosshair. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
-	Sandbox_Advanced_trajectorycrosshairGreen = "Crosshair Focus Green Value",
-	Sandbox_Advanced_trajectorycrosshairGreen_tooltip = "Linked to color when there is zero bloom on crosshair. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+
+	
 	Sandbox_Advanced_trajectoryrecoilModifier = "Recoil Modifier",
 	Sandbox_Advanced_trajectoryrecoilModifier_tooltip = "Multiplier of gun's max dmg added as recoil to crosshair (adds bloom when shooting).",
 
@@ -86,9 +79,15 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectoryMaxProjCone = "Max Projectile Cone (All guns but shotguns)",
 	Sandbox_Advanced_trajectorymaxaimnum = "Max bloom / Maxaimnum",
 	Sandbox_Advanced_trajectorymaxaimnum_tooltip = "Value that limits how much bloom is added to crosshair. Higher means larger possible bloom.",
-
 	Sandbox_Advanced_trajectoryminaimnumModifier = "Minaimnum Modifier",
 	Sandbox_Advanced_trajectoryminaimnumModifier_tooltip = "Value that affects crosshair's minimum bloom. Characters with low aiming level (0-2) will never be accurate (always has bloom). Set to 0 if you want to be OP or unlock focus mechanic at level 3.",
+	Sandbox_Advanced_trajectoryfocusLevel = "Focus Level",
+	Sandbox_Advanced_trajectoryfocusLevel_tooltip = "Aiming level in which player unlocks the focus mechanic.",
+	
+	Sandbox_Advanced_trajectoryenableDistanceLimitPenalty = "Enable Distance Limit Penalty",
+	Sandbox_Advanced_trajectoryenableDistanceLimitPenalty_tooltip = "Player loses accuracy when trying to shoot targets past their distance limit. Uncheck to disable.",
+	Sandbox_Advanced_trajectorydistanceFocusPenalty = "Distance Focus Penalty",
+	Sandbox_Advanced_trajectorydistanceFocusPenalty_tooltip = "Higher means more punishing bloom scaling.",
 
 	Sandbox_Advanced_trajectorymoveeffect = "Moving Effect",
 	Sandbox_Advanced_trajectorymoveeffect_tooltip = "Value that adds bloom when moving.",
@@ -103,10 +102,10 @@ Sandbox_EN = {
 
 	Sandbox_Advanced_trajectorybulletdistance = "Ballistic Distance / Bullet Distance",
 
-	Sandbox_Advanced_trajectoryshotgunnum = "Shotgun Projectile Count / Shotgunnum",
+	Sandbox_Advanced_trajectoryshotgunnum = "Shotgun Projectile Count",
 	Sandbox_Advanced_trajectoryshotgunnum_tooltip = "Amount of pellots shot",
 
-	Sandbox_Advanced_trajectorymaxShotgunProjCone = "Max Projectile Cone (Shotgun)",
+	Sandbox_Advanced_trajectorymaxShotgunProjCone = "Max Projectile Cone (Shotguns)",
 	Sandbox_Advanced_trajectorymaxShotgunProjCone_tooltip = "Shotgun has a max independent projectile cone.",
 
 	Sandbox_Advanced_trajectoryshotgunDistanceModifier = "Shotgun Distance Modifier",
@@ -134,6 +133,10 @@ Sandbox_EN = {
 
 
 
+	Sandbox_Advanced_trajectorycrouchFocusLimitBuff = "Crouch Buff: Reduce minimum bloom limit",
+	Sandbox_Advanced_trajectorycrouchFocusLimitBuff_tooltip = "Reduces minimum bloom limit by a percentage; lower means smaller crosshair",
+	Sandbox_Advanced_trajectoryproneFocusLimitBuff = "Prone Buff: Reduce minimum bloom limit",
+	Sandbox_Advanced_trajectoryproneFocusLimitBuff_tooltip = "Reduces minimum bloom limit by a percentage; lower means smaller crosshair"",
 
 	Sandbox_Advanced_trajectorycrouchReduceSpeedBuff = "Crouch Buff: Reduce Speed",
 	Sandbox_Advanced_trajectorycrouchReduceSpeedBuff_tooltip = "When crouching, your crosshair reduces bloom faster. Helpful after intense cardio.",
@@ -229,4 +232,51 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectoryexhaleModifier3 = "Endurance level 3: Exhale time modifier",
 	Sandbox_Advanced_trajectoryinhaleModifier4 = "Endurance level 4: Inhale time modifier",
 	Sandbox_Advanced_trajectoryexhaleModifier4 = "Endurance level 4: Exhale time modifier",
+
+
+
+
+
+	Sandbox_Advanced_trajectoryenableHitOrMiss 				= "Enable Hit or Miss",
+	Sandbox_Advanced_trajectoryenableHitOrMiss_tooltip 		= "If enabled, player will have a chance of missing depending on bloom. Bullet will pass through zombies without damaging them.",
+	Sandbox_Advanced_trajectoryannounceHitOrMiss 			= "Say Hit or Miss (DEBUG)",
+	Sandbox_Advanced_trajectoryannounceHitOrMiss_tooltip 	= "Player will announce if their bullet hit or missed with bloom value comparisons.",
+	Sandbox_Advanced_trajectoryhitLevelScaling				= "Hitchance Level Scaling",
+	Sandbox_Advanced_trajectoryhitLevelScaling_tooltip 		= "Affects how much aiming level will decrease the chances of not missing. Higher means lower chance of missing per level.",
+	Sandbox_Advanced_trajectoryshotgunHitBuff 				= "Shotgun Hitchance Buff",
+	Sandbox_Advanced_trajectoryshotgunHitBuff_tooltip 		= "A flat value that gives a flat increase in chances of hitting zombies with a shotgun.",
+	Sandbox_Advanced_trajectorymissMin 						= "Min Miss",
+	Sandbox_Advanced_trajectorymissMin_tooltip 				= "Bloom value in which player will start having a chance of missing. Must be less than max. rand(minMiss + buff + aimLevel*hitScaling, maxMiss)",
+	Sandbox_Advanced_trajectorymissMax 						= "Max Miss.",
+	Sandbox_Advanced_trajectorymissMax_tooltip 				= "Look at description for Min Miss.",
+
+
+
+
+
+
+
+
+
+
+	Sandbox_Advanced_trajectorycrosshairRedMain = "Crosshair Main [Red Value]",
+	Sandbox_Advanced_trajectorycrosshairRedMain_tooltip = "Linked to crosshair color. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+	Sandbox_Advanced_trajectorycrosshairBlueMain = "Crosshair Main [Blue Value]",
+	Sandbox_Advanced_trajectorycrosshairBlueMain_tooltip = "Linked to crosshair color. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+	Sandbox_Advanced_trajectorycrosshairGreenMain = "Crosshair Main [Green Value]",
+	Sandbox_Advanced_trajectorycrosshairGreenMain_tooltip = "Linked to crosshair color. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+	
+	Sandbox_Advanced_trajectorycrosshairRed = "Crosshair Focus [Red Value]",
+	Sandbox_Advanced_trajectorycrosshairRed_tooltip = "Linked to color when there is zero bloom on crosshair. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+	Sandbox_Advanced_trajectorycrosshairBlue = "Crosshair Focus [Blue Value]",
+	Sandbox_Advanced_trajectorycrosshairBlue_tooltip = "Linked to color when there is zero bloom on crosshair. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+	Sandbox_Advanced_trajectorycrosshairGreen = "Crosshair Focus [Green Value]",
+	Sandbox_Advanced_trajectorycrosshairGreen_tooltip = "Linked to color when there is zero bloom on crosshair. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+	
+	Sandbox_Advanced_trajectorycrosshairRedLimit = "Crosshair Out of Range [Red Value]",
+	Sandbox_Advanced_trajectorycrosshairRedLimit_tooltip = "Linked to color when crosshair is out of range. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+	Sandbox_Advanced_trajectorycrosshairBlueLimit = "Crosshair Out of Range [Blue Value]",
+	Sandbox_Advanced_trajectorycrosshairBlueLimit_tooltip = "Linked to color when crosshair is out of range. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
+	Sandbox_Advanced_trajectorycrosshairGreenLimit = "Crosshair Out of Range [Green Value]",
+	Sandbox_Advanced_trajectorycrosshairGreenLimit_tooltip = "Linked to color when crosshair is out of range. Pick a color value from 0 to 255 and divide it by 255, must be from 0 to 1.",
 }

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -58,6 +58,12 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectorypenDamageReductionMultiplier = "Bullet Penetration Reduction Multiplier",
 	Sandbox_Advanced_trajectorypenDamageReductionMultiplier_tooltip = "Ex: 0.1 means nerf bullet damage by 90% after penetrating through first zombie/player.",
 
+	Sandbox_Advanced_trajectoryfractureChance = "Gunshot Fracture Chance (PVP)",
+	Sandbox_Advanced_trajectoryfractureChance_tooltip = "Chance that a gunshot wound will cause a fracture",
+
+	Sandbox_Advanced_trajectorythroughChance = "Gunshot Clean Through Chance (PVP)",
+	Sandbox_Advanced_trajectorythroughChance_tooltip = "Chance that a gunshot wound will not inflict a lodged bullet",
+	
 	Sandbox_Advanced_trajectorycritChanceModifier = "Critchance Modifier",
 	Sandbox_Advanced_trajectorycritChanceModifier_tooltip = "Bloom affects crit chance. This is a multiplier to that. Set to 0 for better chances of crit.",
 

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -89,6 +89,12 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectorydistanceFocusPenalty = "Distance Focus Penalty",
 	Sandbox_Advanced_trajectorydistanceFocusPenalty_tooltip = "Higher means more punishing bloom scaling.",
 
+	Sandbox_Advanced_trajectoryrunNGunLv = "Level with Run and Gun Unlocked",
+	Sandbox_Advanced_trajectoryrunNGunLv_tooltip = "When aiming moving and turnin.",
+
+	Sandbox_Advanced_trajectoryrunNGunBuff = "Run and Gun Buff",
+	Sandbox_Advanced_trajectoryrunNGunBuff_tooltip = "Multiplier that reduces penalty for moving and turning. 0.25 means 75% reduction to penalty.",
+
 	Sandbox_Advanced_trajectorymoveeffect = "Moving Effect",
 	Sandbox_Advanced_trajectorymoveeffect_tooltip = "Value that adds bloom when moving.",
 
@@ -124,8 +130,26 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectorymaxFocusSpeed = "Max Focus Speed",
 	Sandbox_Advanced_trajectorymaxFocusSpeed_tooltip = "Part of the focus mechanic. Determines speed of crosshair reducing aimnum to 0 once process has begun.",
 
-	Sandbox_Advanced_trajectoryrecoilDelayModifier = "Recoil Delay Modifier (linked to Focus Counter Speed)",
-	Sandbox_Advanced_trajectoryrecoilDelayModifier_tooltip = "Part of the focus mechanic. Weapon's recoil delay affects how long it takes for character to recover from recoil and this is a multiplier of that. Set to 0 to ignore weapon's recoil delay stat.",
+	Sandbox_Advanced_trajectoryrecoilDelayModifier = "Recoil Delay Modifier",
+	Sandbox_Advanced_trajectoryrecoilDelayModifier_tooltip = "Linked to Focus Counter Speed. Part of the focus mechanic. Weapon's recoil delay affects how long it takes for character to recover from recoil and this is a multiplier of that. Set to 0 to ignore weapon's recoil delay stat.",
+
+	Sandbox_Advanced_trajectoryrecoilScaleModifier = "Recoil Control Modifier",
+	Sandbox_Advanced_trajectoryrecoilScaleModifier_tooltip = "Affects exponential growth of recoil (how much bloom is added depending on the previous bloom value the player shot at). Lower means less added bloom as you continue spraying.",
+
+	Sandbox_Advanced_trajectoryproneRecoilBuff = "Prone Recoil Buff",
+	Sandbox_Advanced_trajectoryproneRecoilBuff_tooltip = "Multiplier reduction to gun recoil.",
+
+	Sandbox_Advanced_trajectoryproneExpoRecoilBuff = "Prone Recoil Control Buff",
+	Sandbox_Advanced_trajectoryproneExpoRecoilBuff_tooltip = "Multiplier that affects how much bloom is added depending on the previous bloom value the player shot at. Lower means less added bloom as you continue spraying.",
+
+	Sandbox_Advanced_trajectorycrouchRecoilBuff = "Crouch Recoil Buff",
+	Sandbox_Advanced_trajectorycrouchRecoilBuff_tooltip = "Multiplier reduction to gun recoil.",
+
+	Sandbox_Advanced_trajectorycrouchExpoRecoilBuff = "Crouch Recoil Control Buff",
+	Sandbox_Advanced_trajectorycrouchExpoRecoilBuff_tooltip = "Multiplier that affects how much bloom is added depending on the previous bloom value the player shot at. Lower means less added bloom as you continue spraying.",
+
+
+
 
 	Sandbox_Advanced_trajectoryshotgundivision = "Shotgun Splitting Angle",
 	Sandbox_Advanced_trajectoryshotgundivision_tooltip = "Value affects shotgun spread. The lower the value, the more narrow the spread.",
@@ -187,6 +211,18 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectorypainVisualModifier = "Shaky crosshair effect (Pain Moodle)",
 	Sandbox_Advanced_trajectorypainVisualModifier_tooltip = "Makes crosshair shaky.",
 
+	Sandbox_Advanced_trajectorypanicPenaltyModifier = "Increased Distance Penalty (Panic Moodle)",   
+	Sandbox_Advanced_trajectorypanicPenaltyModifier_tooltip = "Multiplier that determines how much panic increases the penalty affect when aiming at farther targets.",
+
+	Sandbox_Advanced_trajectorypanicVisualModifier = "Shaky crosshair effect (Panic Moodle)",
+	Sandbox_Advanced_trajectorypanicVisualModifier_tooltip = "Makes crosshair shaky.",
+
+	Sandbox_Advanced_trajectorystressBloomModifier = "Minimum bloom limit (Stress Moodle Scaling)",
+	Sandbox_Advanced_trajectorystressBloomModifier_tooltip = "Multiplier that affects how much is added to minaimnum or minimum bloom.",
+
+	Sandbox_Advanced_trajectorystressVisualModifier = "Shaky crosshair effect (Stress Moodle Scaling)",
+	Sandbox_Advanced_trajectorystressVisualModifier_tooltip = "Affects how intense the crosshair shaking affect is. Set to 0 to disable.",
+
 
 
 	Sandbox_Advanced_trajectorydrunkActionEffectModifier = "Bloom amplifier on Turning/Moving (Drunk Moodle Scaling)",
@@ -202,14 +238,6 @@ Sandbox_EN = {
 
 	Sandbox_Advanced_trajectorytiredModifier = "Slower bloom reduction rate (Fatigue/Tired Moodle Scaling)",
 	Sandbox_Advanced_trajectorytiredModifier_tooltip = "Multiplier that affects how slow your crosshair reduces bloom.",
-
-
-
-	Sandbox_Advanced_trajectorystressBloomModifier = "Minimum bloom limit (Stress Moodle Scaling)",
-	Sandbox_Advanced_trajectorystressBloomModifier_tooltip = "Multiplier that affects how much is added to minaimnum or minimum bloom.",
-
-	Sandbox_Advanced_trajectorystressVisualModifier = "Shaky crosshair effect (Stress Moodle Scaling)",
-	Sandbox_Advanced_trajectorystressVisualModifier_tooltip = "Affects how intense the crosshair shaking affect is. Set to 0 to disable.",
 
 
 
@@ -247,8 +275,8 @@ Sandbox_EN = {
 	Sandbox_Advanced_trajectoryshotgunHitBuff_tooltip 		= "A flat value that gives a flat increase in chances of hitting zombies with a shotgun.",
 	Sandbox_Advanced_trajectorymissMin 						= "Min Miss",
 	Sandbox_Advanced_trajectorymissMin_tooltip 				= "Bloom value in which player will start having a chance of missing. Must be less than max. rand(minMiss + buff + aimLevel*hitScaling, maxMiss)",
-	Sandbox_Advanced_trajectorymissMax 						= "Max Miss.",
-	Sandbox_Advanced_trajectorymissMax_tooltip 				= "Look at description for Min Miss.",
+	Sandbox_Advanced_trajectorymissMax 						= "Max Miss",
+	Sandbox_Advanced_trajectorymissMax_tooltip 				= "Bloom value in which player will start having a chance of missing. Must be greater than min. rand(minMiss + buff + aimLevel*hitScaling, maxMiss)",
 
 
 

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
@@ -192,7 +192,7 @@ option Advanced_trajectory.MaxProjCone
 	type = double,
 	min = 0,
 	max = 1,
-	default = 0.6,
+	default = 0.4,
 	page = Advanced_trajectory,
 	translation = Advanced_trajectoryMaxProjCone,
 }
@@ -310,7 +310,7 @@ option Advanced_trajectory.shotgunHitBuff
 	type = double,
 	min = 0,
 	max = 200,
-	default = 50,
+	default = 60,
 	page = Advanced_trajectory_hitOrMiss,
 	translation = Advanced_trajectoryshotgunHitBuff,
 }
@@ -659,7 +659,7 @@ option Advanced_trajectory.fractureChance
 	type = double,
 	min = 0,
 	max = 100,
-	default = 25,
+	default = 10,
 	page = Advanced_trajectory_damage,
 	translation = Advanced_trajectoryfractureChance,
 }

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
@@ -385,8 +385,8 @@ option Advanced_trajectory.proneExpoRecoilBuff
 {
 	type = double,
 	min = 0,
-	max = 200,
-	default = 40,
+	max = 1,
+	default = 0.5,
 	page = Advanced_trajectory_recoil,
 	translation = Advanced_trajectoryproneExpoRecoilBuff,
 }
@@ -403,8 +403,8 @@ option Advanced_trajectory.crouchExpoRecoilBuff
 {
 	type = double,
 	min = 0,
-	max = 200,
-	default = 60,
+	max = 1,
+	default = 0.75,
 	page = Advanced_trajectory_recoil,
 	translation = Advanced_trajectorycrouchExpoRecoilBuff,
 }
@@ -423,7 +423,7 @@ option Advanced_trajectory.bulletdistance
 	type = double,
 	min = 0,
 	max = 100,
-	default = 1.5,
+	default = 4,
 	page = Advanced_trajectory,
 	translation = Advanced_trajectorybulletdistance,
 }
@@ -432,6 +432,24 @@ option Advanced_trajectory.bulletdistance
 
 
 
+option Advanced_trajectory.runNGunLv
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 10,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectoryrunNGunLv,
+}
+option Advanced_trajectory.runNGunBuff
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0.5,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectoryrunNGunBuff,
+}
 
 option Advanced_trajectory.moveeffect
 {
@@ -664,7 +682,7 @@ option Advanced_trajectory.shotgunDistanceModifier
 	type = double,
 	min = 0,
 	max = 10,
-	default = 2.7,
+	default = 0.5,
 	page = Advanced_trajectory_shotgun,
 	translation = Advanced_trajectoryshotgunDistanceModifier,
 }
@@ -756,24 +774,6 @@ option Advanced_trajectory.heavyTurnEffectModifier
 	page = Advanced_trajectory_moodles,
 	translation = Advanced_trajectoryheavyTurnEffectModifier,
 }
-option Advanced_trajectory.painModifier
-{
-	type = double,
-	min = 0,
-	max = 1,
-	default = 0.1,
-	page = Advanced_trajectory_moodles,
-	translation = Advanced_trajectorypainModifier,
-}
-option Advanced_trajectory.painVisualModifier
-{
-	type = double,
-	min = 0,
-	max = 100,
-	default = 3,
-	page = Advanced_trajectory_moodles,
-	translation = Advanced_trajectorypainVisualModifier,
-}
 option Advanced_trajectory.drunkActionEffectModifier
 {
 	type = double,
@@ -818,6 +818,42 @@ option Advanced_trajectory.tiredModifier
 	default = 0.5,
 	page = Advanced_trajectory_moodles,
 	translation = Advanced_trajectorytiredModifier,
+}
+option Advanced_trajectory.painModifier
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0.1,
+	page = Advanced_trajectory_moodles,
+	translation = Advanced_trajectorypainModifier,
+}
+option Advanced_trajectory.painVisualModifier
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 2,
+	page = Advanced_trajectory_moodles,
+	translation = Advanced_trajectorypainVisualModifier,
+}
+option Advanced_trajectory.panicPenaltyModifier
+{
+	type = double,
+	min = 0,
+	max = 5,
+	default = 3,
+	page = Advanced_trajectory_moodles,
+	translation = Advanced_trajectorypanicPenaltyModifier,
+}
+option Advanced_trajectory.panicVisualModifier
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 1,
+	page = Advanced_trajectory_moodles,
+	translation = Advanced_trajectorypanicVisualModifier,
 }
 option Advanced_trajectory.stressBloomModifier
 {

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
@@ -654,7 +654,24 @@ option Advanced_trajectory.critChanceModifier
 	page = Advanced_trajectory_damage,
 	translation = Advanced_trajectorycritChanceModifier,
 }
-
+option Advanced_trajectory.fractureChance
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 25,
+	page = Advanced_trajectory_damage,
+	translation = Advanced_trajectoryfractureChance,
+}
+option Advanced_trajectory.throughChance
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 25,
+	page = Advanced_trajectory_damage,
+	translation = Advanced_trajectorythroughChance,
+}
 
 
 

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/sandbox-options.txt
@@ -42,6 +42,11 @@ option ATY_damagedisplay
 option AT_Blood
 {type = integer,page = Advanced_trajectory_damage,translation = ATblood,default = 100, min = 0, max = 100,}
 
+
+
+
+
+
 /* ------Damage multiplier (overall)------ */
 option Advanced_trajectory.ATY_damage
 {
@@ -52,6 +57,22 @@ option Advanced_trajectory.ATY_damage
 	page = Advanced_trajectory_damage,
 	translation = Advanced_trajectoryATY_damage,
 }
+option Advanced_trajectory.penDamageReductionMultiplier
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0.25,
+	page = Advanced_trajectory_damage,
+	translation = Advanced_trajectorypenDamageReductionMultiplier,
+}
+
+
+
+
+
+
+
 
 option Advanced_trajectory.DebugOffset
 {
@@ -137,6 +158,11 @@ option Advanced_trajectory.bowBreakChance
 	translation = Advanced_trajectorybowBreakChance,
 }
 
+
+
+
+
+
 option Advanced_trajectory.XPKillModifier
 {
 	type = double,
@@ -146,7 +172,6 @@ option Advanced_trajectory.XPKillModifier
 	page = Advanced_trajectory_XP,
 	translation = Advanced_trajectoryXPKillModifier,
 }
-
 option Advanced_trajectory.XPHitModifier
 {
 	type = double,
@@ -157,26 +182,20 @@ option Advanced_trajectory.XPHitModifier
 	translation = Advanced_trajectoryXPHitModifier,
 }
 
-option Advanced_trajectory.penDamageReductionMultiplier
-{
-	type = double,
-	min = 0,
-	max = 1,
-	default = 0.25,
-	page = Advanced_trajectory_damage,
-	translation = Advanced_trajectorypenDamageReductionMultiplier,
-}
+
+
+
+
 
 option Advanced_trajectory.MaxProjCone
 {
 	type = double,
 	min = 0,
 	max = 1,
-	default = 0.7,
+	default = 0.6,
 	page = Advanced_trajectory,
 	translation = Advanced_trajectoryMaxProjCone,
 }
-
 option Advanced_trajectory.maxaimnum
 {
 	type = double,
@@ -186,7 +205,6 @@ option Advanced_trajectory.maxaimnum
 	page = Advanced_trajectory,
 	translation = Advanced_trajectorymaxaimnum,
 }
-
 option Advanced_trajectory.minaimnumModifier
 {
 	type = double,
@@ -196,6 +214,335 @@ option Advanced_trajectory.minaimnumModifier
 	page = Advanced_trajectory,
 	translation = Advanced_trajectoryminaimnumModifier,
 }
+option Advanced_trajectory.focusLevel
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 3,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectoryfocusLevel,
+}
+
+
+option Advanced_trajectory.enableDistanceLimitPenalty
+{
+	type = boolean,
+	default = true,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectoryenableDistanceLimitPenalty,
+}
+option Advanced_trajectory.distanceFocusPenalty
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 2,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectorydistanceFocusPenalty,
+}
+
+option Advanced_trajectory.reloadEffectModifier
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 0.1,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectoryreloadEffectModifier,
+}
+option Advanced_trajectory.reducespeed
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 1.1,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectoryreducespeed,
+}
+
+
+option Advanced_trajectory.focusCounterSpeed
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 3,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectoryfocusCounterSpeed,
+}
+option Advanced_trajectory.focusCounterSpeedScaleModifier
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 7,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectoryfocusCounterSpeedScaleModifier,
+}
+option Advanced_trajectory.maxFocusSpeed
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 1,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectorymaxFocusSpeed,
+}
+
+
+option Advanced_trajectory.enableHitOrMiss
+{
+	type = boolean,
+	default = true,
+	page = Advanced_trajectory_hitOrMiss,
+	translation = Advanced_trajectoryenableHitOrMiss,
+}
+option Advanced_trajectory.announceHitOrMiss
+{
+	type = boolean,
+	default = false,
+	page = Advanced_trajectory_hitOrMiss,
+	translation = Advanced_trajectoryannounceHitOrMiss,
+}
+option Advanced_trajectory.shotgunHitBuff
+{
+	type = double,
+	min = 0,
+	max = 200,
+	default = 50,
+	page = Advanced_trajectory_hitOrMiss,
+	translation = Advanced_trajectoryshotgunHitBuff,
+}
+option Advanced_trajectory.hitLevelScaling
+{
+	type = double,
+	min = 0,
+	max = 20,
+	default = 3,
+	page = Advanced_trajectory_hitOrMiss,
+	translation = Advanced_trajectoryhitLevelScaling,
+}
+option Advanced_trajectory.missMin
+{
+	type = double,
+	min = 0,
+	max = 300,
+	default = 15,
+	page = Advanced_trajectory_hitOrMiss,
+	translation = Advanced_trajectorymissMin,
+}
+option Advanced_trajectory.missMax
+{
+	type = double,
+	min = 0,
+	max = 300,
+	default = 100,
+	page = Advanced_trajectory_hitOrMiss,
+	translation = Advanced_trajectorymissMax,
+}
+
+
+
+
+option Advanced_trajectory.recoilDelayModifier
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0.01,
+	page = Advanced_trajectory_recoil,
+	translation = Advanced_trajectoryrecoilDelayModifier,
+}
+option Advanced_trajectory.recoilModifier
+{
+	type = double,
+	min = 0,
+	max = 30,
+	default = 10,
+	page = Advanced_trajectory_recoil,
+	translation = Advanced_trajectoryrecoilModifier,
+}
+option Advanced_trajectory.recoilScaleModifier
+{
+	type = double,
+	min = 0,
+	max = 200,
+	default = 80,
+	page = Advanced_trajectory_recoil,
+	translation = Advanced_trajectoryrecoilScaleModifier,
+}
+option Advanced_trajectory.proneRecoilBuff
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0.7,
+	page = Advanced_trajectory_recoil,
+	translation = Advanced_trajectoryproneRecoilBuff,
+}
+option Advanced_trajectory.proneExpoRecoilBuff
+{
+	type = double,
+	min = 0,
+	max = 200,
+	default = 40,
+	page = Advanced_trajectory_recoil,
+	translation = Advanced_trajectoryproneExpoRecoilBuff,
+}
+option Advanced_trajectory.crouchRecoilBuff
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0.8,
+	page = Advanced_trajectory_recoil,
+	translation = Advanced_trajectorycrouchRecoilBuff,
+}
+option Advanced_trajectory.crouchExpoRecoilBuff
+{
+	type = double,
+	min = 0,
+	max = 200,
+	default = 60,
+	page = Advanced_trajectory_recoil,
+	translation = Advanced_trajectorycrouchExpoRecoilBuff,
+}
+
+option Advanced_trajectory.bulletspeed
+{
+	type = double,
+	min = 0,
+	max = 2.4,
+	default = 2.4,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectorybulletspeed,
+}
+option Advanced_trajectory.bulletdistance
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 1.5,
+	page = Advanced_trajectory,
+	translation = Advanced_trajectorybulletdistance,
+}
+
+
+
+
+
+
+option Advanced_trajectory.moveeffect
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 1.3,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectorymoveeffect,
+}
+option Advanced_trajectory.turningeffect
+{
+	type = double,
+	min = 0,
+	max = 100,
+	default = 0.7,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectoryturningeffect,
+}
+option Advanced_trajectory.crouchCounterSpeed
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 8,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectorycrouchCounterSpeed,
+}
+option Advanced_trajectory.crouchPenaltyModifier
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 2,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectorycrouchPenaltyModifier,
+}
+option Advanced_trajectory.crouchTurnEffect
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 3,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectorycrouchTurnEffect,
+}
+option Advanced_trajectory.proneTurnEffect
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 5,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectoryproneTurnEffect,
+}
+
+option Advanced_trajectory.crouchFocusLimitBuff
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0.5,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectorycrouchFocusLimitBuff,
+}
+option Advanced_trajectory.proneFocusLimitBuff
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0.3,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectoryproneFocusLimitBuff,
+}
+
+option Advanced_trajectory.proneFocusCounterSpeedBuff
+{
+	type = double,
+	min = 0,
+	max = 10,
+	default = 1.5,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectoryproneFocusCounterSpeedBuff,
+}
+option Advanced_trajectory.proneReduceSpeedBuff
+{
+	type = double,
+	min = 0,
+	max = 2,
+	default = 0.4,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectoryproneReduceSpeedBuff,
+}
+option Advanced_trajectory.crouchReduceSpeedBuff
+{
+	type = double,
+	min = 0,
+	max = 2,
+	default = 0.2,
+	page = Advanced_trajectory_movement,
+	translation = Advanced_trajectorycrouchReduceSpeedBuff,
+}
+
+
+
+
+
+
+
+
+
 
 option Advanced_trajectory.maxDefenseReduction
 {
@@ -206,13 +553,6 @@ option Advanced_trajectory.maxDefenseReduction
 	page = Advanced_trajectory_damage,
 	translation = Advanced_trajectorymaxDefenseReduction,
 }
-
-
-
-
-
-
-
 
 option Advanced_trajectory.headShotIncChance
 {
@@ -287,15 +627,6 @@ option Advanced_trajectory.footShotDmgPlayerMultiplier
 	page = Advanced_trajectory_damage,
 	translation = Advanced_trajectoryfootShotDmgPlayerMultiplier,
 }
-
-
-
-
-
-
-
-
-
 option Advanced_trajectory.critChanceModifier
 {
 	type = double,
@@ -306,25 +637,17 @@ option Advanced_trajectory.critChanceModifier
 	translation = Advanced_trajectorycritChanceModifier,
 }
 
-option Advanced_trajectory.bulletspeed
-{
-	type = double,
-	min = 0,
-	max = 2.4,
-	default = 1.7,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectorybulletspeed,
-}
 
-option Advanced_trajectory.bulletdistance
-{
-	type = double,
-	min = 0,
-	max = 100,
-	default = 1,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectorybulletdistance,
-}
+
+
+
+
+
+
+
+
+
+
 
 option Advanced_trajectory.maxShotgunProjCone
 {
@@ -340,8 +663,8 @@ option Advanced_trajectory.shotgunDistanceModifier
 {
 	type = double,
 	min = 0,
-	max = 5,
-	default = 0.75,
+	max = 10,
+	default = 2.7,
 	page = Advanced_trajectory_shotgun,
 	translation = Advanced_trajectoryshotgunDistanceModifier,
 }
@@ -386,156 +709,6 @@ option Advanced_trajectory.critChanceModifierShotgunsOnly
 	translation = Advanced_trajectorycritChanceModifierShotgunsOnly,
 }
 
-option Advanced_trajectory.moveeffect
-{
-	type = double,
-	min = 0,
-	max = 100,
-	default = 1.3,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectorymoveeffect,
-}
-
-option Advanced_trajectory.turningeffect
-{
-	type = double,
-	min = 0,
-	max = 100,
-	default = 0.7,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryturningeffect,
-}
-
-option Advanced_trajectory.reloadEffectModifier
-{
-	type = double,
-	min = 0,
-	max = 10,
-	default = 0.1,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryreloadEffectModifier,
-}
-
-option Advanced_trajectory.reducespeed
-{
-	type = double,
-	min = 0,
-	max = 100,
-	default = 1.1,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryreducespeed,
-}
-
-option Advanced_trajectory.focusCounterSpeed
-{
-	type = double,
-	min = 0,
-	max = 10,
-	default = 2,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryfocusCounterSpeed,
-}
-option Advanced_trajectory.focusCounterSpeedScaleModifier
-{
-	type = double,
-	min = 0,
-	max = 10,
-	default = 7,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryfocusCounterSpeedScaleModifier,
-}
-option Advanced_trajectory.maxFocusSpeed
-{
-	type = double,
-	min = 0,
-	max = 1,
-	default = 1,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectorymaxFocusSpeed,
-}
-
-option Advanced_trajectory.crouchCounterSpeed
-{
-	type = double,
-	min = 0,
-	max = 10,
-	default = 8,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectorycrouchCounterSpeed,
-}
-option Advanced_trajectory.crouchPenaltyModifier
-{
-	type = double,
-	min = 0,
-	max = 10,
-	default = 2,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectorycrouchPenaltyModifier,
-}
-option Advanced_trajectory.crouchTurnEffect
-{
-	type = double,
-	min = 0,
-	max = 10,
-	default = 3,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectorycrouchTurnEffect,
-}
-option Advanced_trajectory.proneTurnEffect
-{
-	type = double,
-	min = 0,
-	max = 10,
-	default = 5,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryproneTurnEffect,
-}
-
-option Advanced_trajectory.proneFocusCounterSpeedBuff
-{
-	type = double,
-	min = 0,
-	max = 10,
-	default = 1.5,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryproneFocusCounterSpeedBuff,
-}
-option Advanced_trajectory.proneReduceSpeedBuff
-{
-	type = double,
-	min = 0,
-	max = 2,
-	default = 0.4,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryproneReduceSpeedBuff,
-}
-option Advanced_trajectory.crouchReduceSpeedBuff
-{
-	type = double,
-	min = 0,
-	max = 2,
-	default = 0.2,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectorycrouchReduceSpeedBuff,
-}
-option Advanced_trajectory.recoilDelayModifier
-{
-	type = double,
-	min = 0,
-	max = 1,
-	default = 0.01,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryrecoilDelayModifier,
-}
-option Advanced_trajectory.recoilModifier
-{
-	type = double,
-	min = 0,
-	max = 20,
-	default = 10,
-	page = Advanced_trajectory,
-	translation = Advanced_trajectoryrecoilModifier,
-}
 
 /* ----------------------------------- MOODLES ----------------------------------- */
 option Advanced_trajectory.staminaCrouchScale
@@ -761,7 +934,7 @@ option Advanced_trajectory.crosshairRed
 	type = double,
 	min = 0,
 	max = 1,
-	default = 0,
+	default = 0.2,
 	page = Advanced_trajectory_crosshair,
 	translation = Advanced_trajectorycrosshairRed,
 }
@@ -779,7 +952,7 @@ option Advanced_trajectory.crosshairBlue
 	type = double,
 	min = 0,
 	max = 1,
-	default = 0.98,
+	default = 0.2,
 	page = Advanced_trajectory_crosshair,
 	translation = Advanced_trajectorycrosshairBlue,
 }
@@ -810,4 +983,32 @@ option Advanced_trajectory.crosshairBlueMain
 	default = 1,
 	page = Advanced_trajectory_crosshair,
 	translation = Advanced_trajectorycrosshairBlueMain,
+}
+
+option Advanced_trajectory.crosshairRedLimit
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 1,
+	page = Advanced_trajectory_crosshair,
+	translation = Advanced_trajectorycrosshairRedLimit,
+}
+option Advanced_trajectory.crosshairGreenLimit
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 1,
+	page = Advanced_trajectory_crosshair,
+	translation = Advanced_trajectorycrosshairGreenLimit,
+}
+option Advanced_trajectory.crosshairBlueLimit
+{
+	type = double,
+	min = 0,
+	max = 1,
+	default = 0,
+	page = Advanced_trajectory_crosshair,
+	translation = Advanced_trajectorycrosshairBlueLimit,
 }

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/scripts/module_ATRY_main.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/scripts/module_ATRY_main.txt
@@ -16,7 +16,7 @@ module Base
 	item aty_Shotguna1
     {
         Type	=	Normal,
-        DisplayName	=	Grenade1,
+        DisplayName	=	Shotguna,
         Icon	=	RifleAmmo308loose,
         WorldStaticModel = aty_Shotguna1,
     }
@@ -45,7 +45,7 @@ module Empty
 	item aty_Shotguna1
     {
         Type	=	Normal,
-        DisplayName	=	Grenade1,
+        DisplayName	=	Shotguna,
         Icon	=	RifleAmmo308loose,
         WorldStaticModel = aty_Shotguna1,
     }

--- a/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/scripts/module_ATRY_main.txt
+++ b/Contents/mods/Advanced Trajectory's Realistic Overhaul/media/scripts/module_ATRY_main.txt
@@ -16,7 +16,7 @@ module Base
 	item aty_Shotguna1
     {
         Type	=	Normal,
-        DisplayName	=	Shotguna,
+        DisplayName	=	Grenade1,
         Icon	=	RifleAmmo308loose,
         WorldStaticModel = aty_Shotguna1,
     }
@@ -45,7 +45,7 @@ module Empty
 	item aty_Shotguna1
     {
         Type	=	Normal,
-        DisplayName	=	Shotguna,
+        DisplayName	=	Grenade1,
         Icon	=	RifleAmmo308loose,
         WorldStaticModel = aty_Shotguna1,
     }


### PR DESCRIPTION
- Everything here can be tweaked and the new mechanics can be disabled
- reworked recoil (can be tweaked)

- player target now has a chance of receiving fractures when shot (10%)
- player target now has a chance of receiving no bullet lodges to simulate bullet piercing through the body (will only generate deep wound; 25%)
- **CREDITS TO dr fish / drfishetti for fracture and no bullet lodges code**

- **added distance penalty mechanic** 
- the farther the player aims, the more bloom. The penalty applies past a certain distance which is dependent on weapon range and aiming level. This makes scopes and sniper rifles to be more desired early game for long distance shooting.

- **reworked panic moodle** (adds shakiness and increases effect of distance penalty)

- **added hit or miss mechanic**
- past a certain bloom value, RNG will determine whether or not you will miss the target
- the minimum bloom value is dependent on aiming level (shotguns will increase it significantly so use shotguns if you want HIGHER CHANCES of hitting zombie)
- it is suggested that players shoot when the crosshair is at its smallest even for those with lower aiming levels with shotguns (encourages shoot -> run -> stop -> shoot rather than simultaneously run and shoot)
- decreased max bullet cone for hit or miss mechanic

- **added compatibility to Run N Gun trait** from Insurgent mod (SEVERELY REDUCES movement and turning penalty)
- the trait it pretty cool so I decided to have this unlocked when the player reaches level 10 aiming (level unlock can be adjusted)